### PR TITLE
fix: use local for return table M

### DIFF
--- a/lua/tailwindcss-colorizer-cmp/colors.lua
+++ b/lua/tailwindcss-colorizer-cmp/colors.lua
@@ -1,4 +1,4 @@
-M = {}
+local M = {}
 
 M.TailwindcssColors = {
   slate = {

--- a/lua/tailwindcss-colorizer-cmp/init.lua
+++ b/lua/tailwindcss-colorizer-cmp/init.lua
@@ -1,4 +1,4 @@
-M = {}
+local M = {}
 
 local config = {
 	color_square_width = 2,


### PR DESCRIPTION
The return table M is defined in a global scope. While this should not affect this plugins functionality, using global M for more plugins might cause very weird bugs. (one of which I spent some time debugging today)